### PR TITLE
Faster State Iteration

### DIFF
--- a/src/states.jl
+++ b/src/states.jl
@@ -9,11 +9,11 @@ function state_from_index(pomdp::RockSamplePOMDP{K}, si::Int) where K
     if si == length(pomdp)
         return pomdp.terminal_state
     end
-    rocks_dim = fill(2, K)
+    rocks_dim = @SVector fill(2, K)
     nx, ny = pomdp.map_size
     s = CartesianIndices((nx, ny, rocks_dim...))[si]
     pos = RSPos(s[1], s[2])
-    rocks = SVector{K, Bool}([(s[i] - 1) for i=3:K+2])
+    rocks = SVector{K, Bool}(s.I[3:(K+2)] .- 1)
     return RSState{K}(pos, rocks)
 end
 
@@ -22,7 +22,7 @@ POMDPs.states(pomdp::RockSamplePOMDP) = pomdp
 
 Base.length(pomdp::RockSamplePOMDP) = pomdp.map_size[1]*pomdp.map_size[2]*2^length(pomdp.rocks_positions) + 1
 
-# we define an iterator over it 
+# we define an iterator over it
 function Base.iterate(pomdp::RockSamplePOMDP, i::Int=1)
     if i > length(pomdp)
         return nothing
@@ -31,7 +31,7 @@ function Base.iterate(pomdp::RockSamplePOMDP, i::Int=1)
     return (s, i+1)
 end
 
-function POMDPs.initialstate(pomdp::RockSamplePOMDP{K}) where K 
+function POMDPs.initialstate(pomdp::RockSamplePOMDP{K}) where K
     probs = normalize!(ones(2^K), 1)
     states = Vector{RSState{K}}(undef, 2^K)
     for (i,rocks) in enumerate(Iterators.product(ntuple(x->[false, true], K)...))


### PR DESCRIPTION
Previous state iterator called `state_from_index` on each iteration which in turn creates `CartesianIndices` for which only a single element is used.

In this PR, the temporary `CartesianIndices` allocation at each iteration is removed by allocating at the very beginning then including it in the iteration state.

The following benchmark is used for comparison:
```julia
rs = RockSamplePOMDP(5,7)
@benchmark collect(states(rs))
```

Previously, we get mean time of: `3.839 ms ±  2.036 ms`
Now, we get: `731.324 μs ± 643.553 μs`

This is a ~5x speedup, and the new array of collected states is equivalent to the vector created with the old iteration method (verified only on `RockSamplePOMDP(5,7)`)