### PR TITLE
modified belief parameter type

### DIFF
--- a/src/actions.jl
+++ b/src/actions.jl
@@ -23,7 +23,7 @@ function POMDPs.actions(pomdp::RockSamplePOMDP{K}, s::RSState) where K
     end
 end
 
-function POMDPs.actions(pomdp::RockSamplePOMDP{K}, b::AbstractParticleBelief) where K
+function POMDPs.actions(pomdp::RockSamplePOMDP{K}, b::Union{AbstractParticleBelief, SparseCat}) where K
     # All states in a belief should have the same position, which is what the valid action space depends on
     state = rand(Random.GLOBAL_RNG, b) 
     return actions(pomdp, state)

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -23,7 +23,7 @@ function POMDPs.actions(pomdp::RockSamplePOMDP{K}, s::RSState) where K
     end
 end
 
-function POMDPs.actions(pomdp::RockSamplePOMDP{K}, b::Union{AbstractParticleBelief, SparseCat}) where K
+function POMDPs.actions(pomdp::RockSamplePOMDP, b)
     # All states in a belief should have the same position, which is what the valid action space depends on
     state = rand(Random.GLOBAL_RNG, b) 
     return actions(pomdp, state)

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -23,7 +23,7 @@ function POMDPs.actions(pomdp::RockSamplePOMDP{K}, s::RSState) where K
     end
 end
 
-function POMDPs.actions(pomdp::RockSamplePOMDP{K}, b::ParticleCollection) where K
+function POMDPs.actions(pomdp::RockSamplePOMDP{K}, b::AbstractParticleBelief) where K
     # All states in a belief should have the same position, which is what the valid action space depends on
     state = rand(Random.GLOBAL_RNG, b) 
     return actions(pomdp, state)


### PR DESCRIPTION
Modified belief parameter type to make it as general as possible.
I've noticed that when using Despot or POMCP both save the belief in a custom structure that extends AbstractParticleBelief and also Particle Collection extends it so I thought I should change the method signature to be as general as possible.